### PR TITLE
Remove licensing from top-level README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,30 +35,3 @@ Our changes to the Fuse Spectrum Emulator are in the [fuse-hermitretro](https://
 We have published the full source code and notes to the "second SD card on a Raspberry Pi Zero"
 problem. This can be found in our [spi-fat-fuse](https://github.com/hermitretro/spi-fat-fuse)
 repository.
-
-# Licensing
-
-```
-MIT License
-
-Copyright (c) 2021 Hermit Retro Products Ltd.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software, schematics and associated documentation files 
-(the "Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish, 
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to 
-the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```


### PR DESCRIPTION
Remove licensing from top-level README as it gets pushed-up into the general hermitretro overview and is inaccurate for all other repos...